### PR TITLE
Define required values for the container

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Bonus: you will get an execution log for each executed workflow - if you want to
 
 * [Installation](#Installation)
 * [Example workflow](#Example-workflow)
+* [Workflow container](#Workflow-container)
 * [Stages](#Stages)
 * [Workflow control](#Workflow-control)
 * [Nested workflows](#Nested-workflows)
@@ -31,6 +32,7 @@ Bonus: you will get an execution log for each executed workflow - if you want to
 ## Installation
 
 The recommended way to install php-workflow is through [Composer](http://getcomposer.org):
+
 ```
 $ composer require wol-soft/php-workflow
 ```
@@ -157,6 +159,8 @@ class AcceptOpenSuggestionForSong implements \PHPWorkflow\Step\WorkflowStep {
 }
 ```
 
+## Workflow container
+
 Now let's have a more detailed look at the **WorkflowContainer** which helps us, to share data and objects between our workflow steps.
 The relevant objects for our example workflow is the **User** who wants to add the song, the **Song** object of the song to add and the **Playlist** object.
 Before we execute our workflow we can set up a **WorkflowContainer** which contains all relevant objects:
@@ -167,6 +171,22 @@ $workflowContainer = (new \PHPWorkflow\State\WorkflowContainer())
     ->set('song', (new SongRepository())->getSongById($request->get('songId')))
     ->set('playlist', (new PlaylistRepository())->getPlaylistById($request->get('playlistId')));
 ```
+
+The workflow container provides the following interface:
+
+```php
+// returns an item or null if the key doesn't exist
+public function get(string $key)
+// set or update a value
+public function set(string $key, $value): self
+// remove an entry
+public function unset(string $key): self
+// check if a key exists
+public function has(string $key): bool
+```
+
+Each workflow step may define requirements, which entries must be present in the workflow container before the step is executed.
+For more details have a look at [Required container values](#Required-container-values).
 
 Alternatively to set and get the values from the **WorkflowContainer** via string keys you can extend the **WorkflowContainer** and add typed properties/functions to handle values in a type-safe manner:
 
@@ -194,7 +214,7 @@ $workflowResult = (new \PHPWorkflow\Workflow('AddSongToPlaylist'))
     ->executeWorkflow($workflowContainer);
 ```
 
-Another possibility would be to define a step in the **Prepare** stage (e.g. **PopulateAddSongToPlaylistContainer**) which populates the injected **WorkflowContainer** object.
+Another possibility would be to define a step in the **Prepare** stage (e.g. **PopulateAddSongToPlaylistContainer**) which populates the automatically injected empty **WorkflowContainer** object.
 
 ## Stages
 
@@ -557,11 +577,11 @@ By default a string representation of the execution will be returned (just like 
 
 Currently the following additional formatters are implemented:
 
-`, ` Formatter       `, ` Description   `, `
-`, ` --------------- `, ` ------------- `, `
-`, ` `StringLog`     `, ` The default formatter. Creates a string representation. <br />Example:<br />`$result->debug();` `, `
-`, ` `WorkflowGraph` `, ` Creates a SVG file containing a graph which represents the workflow execution. The generated image will be stored in the provided target directory. Requires `dot` executable.<br />Example:<br />`$result->debug(new WorkflowGraph('/var/log/workflow/graph'));` `, `
-`, ` `GraphViz`      `, ` Returns a string containing [GraphViz](https://graphviz.org/) code for a graph representing the workflow execution.  <br />Example:<br />`$result->debug(new GraphViz());``, `
+| Formatter       | Description   |
+| --------------- | ------------- |
+| `StringLog`     | The default formatter. Creates a string representation. <br />Example:<br />`$result->debug();` |
+| `WorkflowGraph` | Creates a SVG file containing a graph which represents the workflow execution. The generated image will be stored in the provided target directory. Requires `dot` executable.<br />Example:<br />`$result->debug(new WorkflowGraph('/var/log/workflow/graph'));` |
+| `GraphViz`      | Returns a string containing [GraphViz](https://graphviz.org/) code for a graph representing the workflow execution.  <br />Example:<br />`$result->debug(new GraphViz());`|
 
 ## Tests
 

--- a/src/Exception/WorkflowStepDependencyNotFulfilledException.php
+++ b/src/Exception/WorkflowStepDependencyNotFulfilledException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHPWorkflow\Exception;
+
+use Exception;
+
+class WorkflowStepDependencyNotFulfilledException extends Exception
+{
+}

--- a/src/Middleware/WorkflowStepDependencyCheck.php
+++ b/src/Middleware/WorkflowStepDependencyCheck.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHPWorkflow\Middleware;
+
+use PHPWorkflow\Exception\WorkflowStepDependencyNotFulfilledException;
+use PHPWorkflow\State\WorkflowContainer;
+use PHPWorkflow\Step\Dependency\StepDependencyInterface;
+use PHPWorkflow\Step\WorkflowStep;
+use PHPWorkflow\WorkflowControl;
+use ReflectionAttribute;
+use ReflectionException;
+use ReflectionMethod;
+
+class WorkflowStepDependencyCheck
+{
+    /**
+     * @throws ReflectionException
+     * @throws WorkflowStepDependencyNotFulfilledException
+     */
+    public function __invoke(
+        callable $next,
+        WorkflowControl $control,
+        WorkflowContainer $container,
+        WorkflowStep $step,
+    ) {
+        $containerParameter = (new ReflectionMethod($step, 'run'))->getParameters()[1] ?? null;
+
+        if ($containerParameter) {
+            foreach ($containerParameter->getAttributes(
+                    StepDependencyInterface::class,
+                    ReflectionAttribute::IS_INSTANCEOF,
+                ) as $dependencyAttribute
+            ) {
+                /** @var StepDependencyInterface $dependency */
+                $dependency = $dependencyAttribute->newInstance();
+                $dependency->check($container);
+            }
+        }
+
+        return $next();
+    }
+}

--- a/src/State/WorkflowContainer.php
+++ b/src/State/WorkflowContainer.php
@@ -21,7 +21,7 @@ class WorkflowContainer
 
     public function unset(string $key): self
     {
-        $this->unset($this->items[$key]);
+        unset($this->items[$key]);
         return $this;
     }
 

--- a/src/State/WorkflowContainer.php
+++ b/src/State/WorkflowContainer.php
@@ -18,4 +18,15 @@ class WorkflowContainer
         $this->items[$key] = $value;
         return $this;
     }
+
+    public function unset(string $key): self
+    {
+        $this->unset($this->items[$key]);
+        return $this;
+    }
+
+    public function has(string $key): bool
+    {
+        return array_key_exists($key, $this->items);
+    }
 }

--- a/src/Step/Dependency/Requires.php
+++ b/src/Step/Dependency/Requires.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHPWorkflow\Step\Dependency;
+
+use Attribute;
+use PHPWorkflow\Exception\WorkflowStepDependencyNotFulfilledException;
+use PHPWorkflow\State\WorkflowContainer;
+
+#[Attribute(Attribute::TARGET_PARAMETER | Attribute::IS_REPEATABLE)]
+class Requires implements StepDependencyInterface
+{
+    public function __construct(private string $key, private ?string $type = null) {}
+
+    public function check(WorkflowContainer $container): void
+    {
+        if (!$container->has($this->key)) {
+            throw new WorkflowStepDependencyNotFulfilledException("Missing '$this->key' in container");
+        }
+
+        $value = $container->get($this->key);
+
+        if ($this->type === null || (str_starts_with($this->type, '?') && $value === null)) {
+            return;
+        }
+
+        $type = str_replace('?', '', $this->type);
+
+        if (preg_match('/^(string|bool|int|float|object|array|iterable|scalar)$/', $type, $matches) === 1) {
+            $checkMethod = 'is_' . $matches[1];
+
+            if ($checkMethod($value)) {
+                return;
+            }
+        } elseif (class_exists($type) && ($value instanceof $type)) {
+            return;
+        }
+
+        throw new WorkflowStepDependencyNotFulfilledException(
+            sprintf(
+                "Value for '%s' has an invalid type. Expected %s, got %s",
+                $this->key,
+                $this->type,
+                gettype($value) . (is_object($value) ? sprintf(' (%s)', $value::class) : ''),
+            ),
+        );
+    }
+}

--- a/src/Step/Dependency/StepDependencyInterface.php
+++ b/src/Step/Dependency/StepDependencyInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHPWorkflow\Step\Dependency;
+
+use PHPWorkflow\Exception\WorkflowStepDependencyNotFulfilledException;
+use PHPWorkflow\State\WorkflowContainer;
+
+interface StepDependencyInterface
+{
+    /**
+     * @throws WorkflowStepDependencyNotFulfilledException
+     */
+    public function check(WorkflowContainer $container): void;
+}

--- a/tests/StepDependencyTest.php
+++ b/tests/StepDependencyTest.php
@@ -259,7 +259,7 @@ class StepDependencyTest extends TestCase
                 (new WorkflowContainer())->set('created', $input),
                 "Value for 'created' has an invalid type. Expected DateTime, got "
                     . gettype($input)
-                    . (is_object($input) ? sprintf(' (%s)', $input::class) : ''),
+                    . (is_object($input) ? sprintf(' (%s)', get_class($input)) : ''),
             ];
         }
 
@@ -268,7 +268,7 @@ class StepDependencyTest extends TestCase
                 (new WorkflowContainer())->set('created', new DateTime())->set('updated', $input),
                 "Value for 'updated' has an invalid type. Expected ?DateTime, got "
                     . gettype($input)
-                    . (is_object($input) ? sprintf(' (%s)', $input::class) : ''),
+                    . (is_object($input) ? sprintf(' (%s)', get_class($input)) : ''),
             ];
         }
     }

--- a/tests/StepDependencyTest.php
+++ b/tests/StepDependencyTest.php
@@ -1,0 +1,376 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHPWorkflow\Tests;
+
+use DateTime;
+use DateTimeZone;
+use PHPUnit\Framework\TestCase;
+use PHPWorkflow\State\WorkflowContainer;
+use PHPWorkflow\Step\Dependency\Requires;
+use PHPWorkflow\Step\WorkflowStep;
+use PHPWorkflow\Workflow;
+use PHPWorkflow\WorkflowControl;
+
+class StepDependencyTest extends TestCase
+{
+    use WorkflowTestTrait;
+
+    public static function setUpBeforeClass(): void
+    {
+        if (PHP_MAJOR_VERSION < 8) {
+            self::markTestSkipped('Step dependencies require PHP >= 8.0.0');
+        }
+    }
+
+    public function testMissingKeyFails(): void
+    {
+        $result = (new Workflow('test'))
+            ->process($this->requireCustomerIdStep())
+            ->executeWorkflow(null, false);
+
+        $this->assertFalse($result->success());
+
+        $this->assertDebugLog(
+            <<<DEBUG
+            Process log for workflow 'test':
+            Process:
+              - test step with simple require: failed (Missing 'customerId' in container)
+            
+            Summary:
+              - Workflow execution: failed (Missing 'customerId' in container)
+                - Execution time: *
+            DEBUG,
+            $result,
+        );
+    }
+
+    /**
+     * @dataProvider providedKeyDataProvider
+     */
+    public function testProvidedKeySucceeds($input): void
+    {
+        $result = (new Workflow('test'))
+            ->process($this->requireCustomerIdStep())
+            ->executeWorkflow((new WorkflowContainer())->set('customerId', $input));
+
+        $this->assertTrue($result->success());
+
+        $type = gettype($input);
+        $this->assertDebugLog(
+            <<<DEBUG
+            Process log for workflow 'test':
+            Process:
+              - test step with simple require: ok
+                - provided type: $type
+            
+            Summary:
+              - Workflow execution: ok
+                - Execution time: *
+            DEBUG,
+            $result,
+        );
+    }
+
+    public function providedKeyDataProvider(): array
+    {
+        return [
+            'null' => [null],
+            'int' => [10],
+            'float' => [10.5],
+            'bool' => [true],
+            'array' => [[1, 2, 3]],
+            'string' => ['Hello'],
+            'DateTime' => [new DateTime()],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidTypedValueDataProvider
+     */
+    public function testInvalidTypedValueFails(WorkflowContainer $container, string $expectedExceptionMessage): void
+    {
+        $result = (new Workflow('test'))
+            ->process($this->requiredTypedCustomerIdStep())
+            ->executeWorkflow($container, false);
+
+        $this->assertFalse($result->success());
+
+        $this->assertDebugLog(
+            <<<DEBUG
+            Process log for workflow 'test':
+            Process:
+              - test step with typed require: failed ($expectedExceptionMessage)
+            
+            Summary:
+              - Workflow execution: failed ($expectedExceptionMessage)
+                - Execution time: *
+            DEBUG,
+            $result,
+        );
+    }
+
+    public function invalidTypedValueDataProvider(): iterable
+    {
+        yield 'value not provided' => [(new WorkflowContainer()), "Missing 'customerId' in container"];
+
+        foreach ([null, false, 10, 0.0, []] as $input) {
+            yield gettype($input) => [
+                (new WorkflowContainer())->set('customerId', $input),
+                "Value for 'customerId' has an invalid type. Expected string, got " . gettype($input),
+            ];
+        }
+    }
+
+    public function testProvidedTypedKeySucceeds(): void
+    {
+        $result = (new Workflow('test'))
+            ->process($this->requiredTypedCustomerIdStep())
+            ->executeWorkflow((new WorkflowContainer())->set('customerId', 'Hello'));
+
+        $this->assertTrue($result->success());
+
+        $this->assertDebugLog(
+            <<<DEBUG
+            Process log for workflow 'test':
+            Process:
+              - test step with typed require: ok
+            
+            Summary:
+              - Workflow execution: ok
+                - Execution time: *
+            DEBUG,
+            $result,
+        );
+    }
+
+    /**
+     * @dataProvider invalidNullableTypedValueDataProvider
+     */
+    public function testInvalidNullableTypedValueFails(
+        WorkflowContainer $container,
+        string $expectedExceptionMessage
+    ): void {
+        $result = (new Workflow('test'))
+            ->process($this->requiredNullableTypedCustomerIdStep())
+            ->executeWorkflow($container, false);
+
+        $this->assertFalse($result->success());
+
+        $this->assertDebugLog(
+            <<<DEBUG
+            Process log for workflow 'test':
+            Process:
+              - test step with nullable typed require: failed ($expectedExceptionMessage)
+            
+            Summary:
+              - Workflow execution: failed ($expectedExceptionMessage)
+                - Execution time: *
+            DEBUG,
+            $result,
+        );
+    }
+
+    public function invalidNullableTypedValueDataProvider(): iterable
+    {
+        yield 'value not provided' => [(new WorkflowContainer()), "Missing 'customerId' in container"];
+
+        foreach ([false, 10, 0.0, []] as $input) {
+            yield gettype($input) => [
+                (new WorkflowContainer())->set('customerId', $input),
+                "Value for 'customerId' has an invalid type. Expected ?string, got " . gettype($input),
+            ];
+        }
+    }
+
+    /**
+     * @dataProvider providedNullableTypedKeyDataProvider
+     */
+    public function testProvidedNullableTypedKeySucceeds(?string $input): void
+    {
+        $result = (new Workflow('test'))
+            ->process($this->requiredNullableTypedCustomerIdStep())
+            ->executeWorkflow((new WorkflowContainer())->set('customerId', $input));
+
+        $this->assertTrue($result->success());
+
+        $this->assertDebugLog(
+            <<<DEBUG
+            Process log for workflow 'test':
+            Process:
+              - test step with nullable typed require: ok
+            
+            Summary:
+              - Workflow execution: ok
+                - Execution time: *
+            DEBUG,
+            $result,
+        );
+    }
+
+    public function providedNullableTypedKeyDataProvider(): array
+    {
+        return [
+            'null' => [null],
+            'empty string' => [''],
+            'numeric string' => ['123'],
+            'string' => ['Hello World'],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidDateTimeValueDataProvider
+     */
+    public function testInvalidDateTimeValueFails(
+        WorkflowContainer $container,
+        string $expectedExceptionMessage
+    ): void {
+        $result = (new Workflow('test'))
+            ->process($this->requiredDateTimeStep())
+            ->executeWorkflow($container, false);
+
+        $this->assertFalse($result->success());
+
+        $this->assertDebugLog(
+            <<<DEBUG
+            Process log for workflow 'test':
+            Process:
+              - test step with DateTime require: failed ($expectedExceptionMessage)
+            
+            Summary:
+              - Workflow execution: failed ($expectedExceptionMessage)
+                - Execution time: *
+            DEBUG,
+            $result,
+        );
+    }
+
+    public function invalidDateTimeValueDataProvider(): iterable
+    {
+        yield 'created not provided' => [(new WorkflowContainer()), "Missing 'created' in container"];
+        yield 'updated not provided' => [
+            (new WorkflowContainer())->set('created', new DateTime()),
+            "Missing 'updated' in container",
+        ];
+
+        foreach ([null, false, 10, 0.0, [], '', new DateTimeZone('Europe/Berlin')] as $input) {
+            yield 'Invalid value for created - ' . gettype($input) => [
+                (new WorkflowContainer())->set('created', $input),
+                "Value for 'created' has an invalid type. Expected DateTime, got "
+                    . gettype($input)
+                    . (is_object($input) ? sprintf(' (%s)', $input::class) : ''),
+            ];
+        }
+
+        foreach ([false, 10, 0.0, [], '', new DateTimeZone('Europe/Berlin')] as $input) {
+            yield 'Invalid value for updated - ' . gettype($input) => [
+                (new WorkflowContainer())->set('created', new DateTime())->set('updated', $input),
+                "Value for 'updated' has an invalid type. Expected ?DateTime, got "
+                    . gettype($input)
+                    . (is_object($input) ? sprintf(' (%s)', $input::class) : ''),
+            ];
+        }
+    }
+
+
+    /**
+     * @dataProvider providedDateTimeDataProvider
+     */
+    public function testProvidedDateTimeSucceeds(DateTime $created, ?DateTime $updated): void
+    {
+        $result = (new Workflow('test'))
+            ->process($this->requiredDateTimeStep())
+            ->executeWorkflow((new WorkflowContainer())->set('created', $created)->set('updated', $updated));
+
+        $this->assertTrue($result->success());
+
+        $this->assertDebugLog(
+            <<<DEBUG
+            Process log for workflow 'test':
+            Process:
+              - test step with DateTime require: ok
+            
+            Summary:
+              - Workflow execution: ok
+                - Execution time: *
+            DEBUG,
+            $result,
+        );
+    }
+
+    public function providedDateTimeDataProvider(): array
+    {
+        return [
+            'only created' => [new DateTime(), null],
+            'created and updated' => [new DateTime(), new DateTime()],
+        ];
+    }
+
+    public function requireCustomerIdStep(): WorkflowStep
+    {
+        return new class () implements WorkflowStep {
+            public function getDescription(): string
+            {
+                return 'test step with simple require';
+            }
+
+            public function run(
+                WorkflowControl $control,
+                #[Requires('customerId')]
+                WorkflowContainer $container
+            ): void {
+                $control->attachStepInfo('provided type: ' . gettype($container->get('customerId')));
+            }
+        };
+    }
+
+    public function requiredTypedCustomerIdStep(): WorkflowStep
+    {
+        return new class () implements WorkflowStep {
+            public function getDescription(): string
+            {
+                return 'test step with typed require';
+            }
+
+            public function run(
+                WorkflowControl $control,
+                #[Requires('customerId', 'string')]
+                WorkflowContainer $container
+            ): void {}
+        };
+    }
+
+    public function requiredNullableTypedCustomerIdStep(): WorkflowStep
+    {
+        return new class () implements WorkflowStep {
+            public function getDescription(): string
+            {
+                return 'test step with nullable typed require';
+            }
+
+            public function run(
+                WorkflowControl $control,
+                #[Requires('customerId', '?string')]
+                WorkflowContainer $container
+            ): void {}
+        };
+    }
+
+    public function requiredDateTimeStep(): WorkflowStep
+    {
+        return new class () implements WorkflowStep {
+            public function getDescription(): string
+            {
+                return 'test step with DateTime require';
+            }
+
+            public function run(
+                WorkflowControl $control,
+                #[Requires('created', DateTime::class)]
+                #[Requires('updated', '?' . DateTime::class)]
+                WorkflowContainer $container
+            ): void {}
+        };
+    }
+}

--- a/tests/WorkflowContainerTest.php
+++ b/tests/WorkflowContainerTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHPWorkflow\Tests;
+
+use PHPUnit\Framework\TestCase;
+use PHPWorkflow\State\WorkflowContainer;
+
+class WorkflowContainerTest extends TestCase
+{
+    public function testWorkflowContainer(): void
+    {
+        $container = new WorkflowContainer();
+
+        $this->assertFalse($container->has('non existing key'));
+        $this->assertNull($container->get('non existing key'));
+
+        $container->set('key', 42);
+        $this->assertTrue($container->has('key'));
+        $this->assertSame(42, $container->get('key'));
+
+        $container->set('key', 'Updated');
+        $this->assertTrue($container->has('key'));
+        $this->assertSame('Updated', $container->get('key'));
+
+        $container->unset('key');
+        $this->assertFalse($container->has('key'));
+        $this->assertNull($container->get('key'));
+    }
+}


### PR DESCRIPTION
Implement step dependencies via attributes:

```php
public function run(
    \PHPWorkflow\WorkflowControl $control,
    // The key customerId must contain a string
    #[\PHPWorkflow\Step\Dependency\Required('customerId', 'string')]
    // The customerAge must contain an integer. But also null is accepted.
    // Each type definition can be prefixed with a ? to accept null.
    #[\PHPWorkflow\Step\Dependency\Required('customerAge', '?int')]
    // Objects can also be type hinted
    #[\PHPWorkflow\Step\Dependency\Required('created', \DateTime::class)]
    \PHPWorkflow\State\WorkflowContainer $container,
) {
    // Implementation which can rely on the defined keys to be present in the container.
}
```